### PR TITLE
Fixed Linkedin share button and removed Google+

### DIFF
--- a/_includes/share.html
+++ b/_includes/share.html
@@ -7,13 +7,10 @@
 <a class="t" href="https://twitter.com/intent/tweet?text=&url={{site.url}}{{page.url|absolute_path}}" onclick="window.open(this.href, 'mywin',
 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;"><i class="fa fa-twitter fa"></i><span> twitter</span></a>
 
-<a class="g" href="https://plus.google.com/share?url={{site.url}}{{page.url|absolute_path}}" onclick="window.open(this.href, 'mywin',
-'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" ><i class="fa fa-google-plus fa"></i><span> google</span></a>
-
 <a class="r" href="http://www.reddit.com/submit?url={{post.ur|absolute_path}}" onclick="window.open(this.href, 'mywin',
 'left=20,top=20,width=900,height=500,toolbar=1,resizable=0'); return false;" ><i class="fa fa-reddit fa"></i><span> reddit</span></a>
 
-<a class="l" href="https://www.linkedin.com/shareArticle?mini=true&url={{site.url}}{{page.url|absolute_path}}&title={{page.title}}&summary={{page.excerpt}}&source={{site.title}}" onclick="window.open(this.href, 'mywin',
+<a class="l" href="https://www.linkedin.com/shareArticle?mini=true&url={{site.url}}{{page.url|absolute_path}}&title={{page.title}}&source={{site.title}}" onclick="window.open(this.href, 'mywin',
 'left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" ><i class="fa fa-linkedin fa"></i><span> linkedin</span></a>
 
 <a class="e" href="mailto:?subject=&amp;body=Check out this site {{site.url}}{{page.url|absolute_path}}"><i class="fa fa-envelope fa"></i><span> email</span></a>                          


### PR DESCRIPTION
Fixed Linkedin share button by removing the description field from the URL.
Removed Google+ due to its death.

Fixes #8 