### PR TITLE
Bug Fix: 0.6.0 Announcement

### DIFF
--- a/_posts/2020-10-28-vegastrike-0.6.0-release.md
+++ b/_posts/2020-10-28-vegastrike-0.6.0-release.md
@@ -10,21 +10,21 @@ explore. The universe and adventure are yours.
 
 Since our last release in 2012 of Vega Strike 0.5.1 we've made a few minor changes for 0.6.0. With a mostly new development team leading
 the way we've updated the dependencies to work on the newer systems, and fixed a few necessary bugs in the process. Development has also
-moved from our old home at Source Forge (https://sourceforge.net/projects/vegastrike/) to our new home at Git Hub (https://github.com/vegastrike).
+moved from our old home at [Source Forge](https://sourceforge.net/projects/vegastrike/) to our new home at [Git Hub](https://github.com/vegastrike).
 
 ## Want to help out?
 
 There's a lot to do. We're working diligently to update Vega Strike. Version 0.6.0 is just our first step, showing it can still be done.
-We've already got several releases planned in the process of continuing to update our dependencies and fix bugs; you can see our Road Map at
-https://www.vega-strike.org/roadmap/. We need everything from coding, story development, art work, documentation, and even just generally helping the community.
+We've already got several releases planned in the process of continuing to update our dependencies and fix bugs; you can see our [Road Map](https://www.vega-strike.org/roadmap/).
+We need everything from coding, story development, art work, documentation, and even just generally helping the community.
 
-The development team is active at https://gitter.im/vegastrike/community and we'd love to hear from you.
+The development team is active at [Gitter.im](https://gitter.im/vegastrike/community) and we'd love to hear from you.
 
-You can also find the community at https://forums.vega-strike.org/.
+You can also find the community at the [Vega Strike Forums](https://forums.vega-strike.org/).
 
 ## Where can I find the release?
 
-https://github.com/vegastrike/Vega-Strike-Engine-Source/releases/tag/v0.6.0
-https://github.com/vegastrike/Assets-Production/releases/tag/v0.6.2
+[Vega Strike Engine 0.6.0](https://github.com/vegastrike/Vega-Strike-Engine-Source/releases/tag/v0.6.0)
+[Vega Strike: Upon the Coldest Sea 0.6.2](https://github.com/vegastrike/Assets-Production/releases/tag/v0.6.2)
 
 NOTE: Presently just the Linux builds are provided. The Vega Strike Team is still working to restore Mac and Windows support.

--- a/_posts/2020-10-28-vegastrike-0.6.0-release.md
+++ b/_posts/2020-10-28-vegastrike-0.6.0-release.md
@@ -1,6 +1,14 @@
-# Vega Strike 0.6.0 Released!
-
-It is with great pleasure that the Vega Strike Development Team announces the release of Vega Strike 0.6.0.
+---
+layout: post
+title: "Vega Strike 0.6.0 Released!"
+description: "New Releases: Vega Strike 0.6.0, VS:UtCS 0.6.2"
+author: BenjamenMeyer
+date: 2020-10-10 03:22:00 +0000
+categories: website announcements releases community
+excerpt_separator: <!--more-->
+---
+It is with great pleasure that the Vega Strike Development Team announces the release of Vega Strike 0.6.0 and VS:Upon The Coldest Sea 0.6.2.
+<!--more-->
 
 Join our protagonist Deucalion in adventures around the universe as a bounty hunter, mercenary, or merchant flying through the
 stars. Meet the deadly Aera and mysterious Rlaan. Battle with the Confederation. Run alongside Pirates. Or just buy and sell as a merchant while you
@@ -10,21 +18,29 @@ explore. The universe and adventure are yours.
 
 Since our last release in 2012 of Vega Strike 0.5.1 we've made a few minor changes for 0.6.0. With a mostly new development team leading
 the way we've updated the dependencies to work on the newer systems, and fixed a few necessary bugs in the process. Development has also
-moved from our old home at [Source Forge](https://sourceforge.net/projects/vegastrike/) to our new home at [Git Hub](https://github.com/vegastrike).
+moved from our old home at [Source Forge][sf] to our new home at [Git Hub][gh].
 
 ## Want to help out?
 
 There's a lot to do. We're working diligently to update Vega Strike. Version 0.6.0 is just our first step, showing it can still be done.
-We've already got several releases planned in the process of continuing to update our dependencies and fix bugs; you can see our [Road Map](https://www.vega-strike.org/roadmap/).
+We've already got several releases planned in the process of continuing to update our dependencies and fix bugs; you can see our [Road Map][roadmap].
 We need everything from coding, story development, art work, documentation, and even just generally helping the community.
 
-The development team is active at [Gitter.im](https://gitter.im/vegastrike/community) and we'd love to hear from you.
+The development team is active at [Gitter.im][gitter] and we'd love to hear from you.
 
-You can also find the community at the [Vega Strike Forums](https://forums.vega-strike.org/).
+You can also find the community at the [Vega Strike Forums][forums].
 
 ## Where can I find the release?
 
-[Vega Strike Engine 0.6.0](https://github.com/vegastrike/Vega-Strike-Engine-Source/releases/tag/v0.6.0)
-[Vega Strike: Upon the Coldest Sea 0.6.2](https://github.com/vegastrike/Assets-Production/releases/tag/v0.6.2)
+[Vega Strike Engine 0.6.0][vse]
+[Vega Strike: Upon the Coldest Sea 0.6.2][vsutcs]
 
 NOTE: Presently just the Linux builds are provided. The Vega Strike Team is still working to restore Mac and Windows support.
+
+[sf]: https://sourceforge.net/projects/vegastrike/
+[gh]: https://github.com/vegastrike
+[roadmap]: https://www.vega-strike.org/roadmap/
+[gitter]: https://gitter.im/vegastrike/community
+[forums]: https://forums.vega-strike.org/
+[vse]: https://github.com/vegastrike/Vega-Strike-Engine-Source/releases/tag/v0.6.0
+[vsutcs]: https://github.com/vegastrike/Assets-Production/releases/tag/v0.6.2


### PR DESCRIPTION
- change filename so title shows "0.6.0" instead of "0 6 0"
- fix links to show up as links in MarkDown