### PR TITLE
Bug Fix/Enhancement: Install & Downloads

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,9 @@ github_username:  vegastrike
 gitter: https://gitter.im/vegastrike/community
 google_site_verification: z7w-3d4YMTeLVhjeVElqaV1_qmjG-zKJzKGVDgZucvY
 
+engine_download_url: https://github.com/vegastrike/Vega-Strike-Engine-Source/releases
+vsutcs_download_url: https://github.com/vegastrike/Assets-Production/releases
+
 # theme options from https://bootswatch.com/3/
 # comment out this to use default Bootstrap
 bootwatch: cyborg #paper cerulean cosmo custom cyborg darkly flatly journal lumen readable sandstone simplex slate solar spacelab superhero united yeti

--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@ layout: default
         <h1>Vega Strike Project</h1>
         <p>Open Source 3D Space Flight Sim: Trade, Fight, Explore</p>
         <div class="container">
+         <dt><a class="btn btn-primary btn-lg" href="{{ site.url }}/install" target="_blank" role="button">Install Vega Strike</a></dt>
+         <dt><!-- just some emtpy content so that there's some space between the buttons -->&nbsp;</dt>
          <dt><a class="btn btn-primary btn-lg" href="{{ site.engine_download_url }}" role="button">Download Vega Strike Engine</a></dt>
          <dt><!-- just some emtpy content so that there's some space between the buttons -->&nbsp;</dt>
          <dt><a class="btn btn-primary btn-lg" href="{{ site.vsutcs_download_url }}" role="button">Download Vega Strike: Upon the Coldest Sea</a></dt>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,11 @@ layout: default
     <div class="container">
         <h1>Vega Strike Project</h1>
         <p>Open Source 3D Space Flight Sim: Trade, Fight, Explore</p>
-        <p><a class="btn btn-primary btn-lg" href="{{ site.git_address }}/releases" role="button">Download Now</a></p>
+        <div class="container">
+         <dt><a class="btn btn-primary btn-lg" href="{{ site.engine_download_url }}" role="button">Download Vega Strike Engine</a></dt>
+         <dt><!-- just some emtpy content so that there's some space between the buttons -->&nbsp;</dt>
+         <dt><a class="btn btn-primary btn-lg" href="{{ site.vsutcs_download_url }}" role="button">Download Vega Strike: Upon the Coldest Sea</a></dt>
+        </div>
     </div>
 </div>
 <div class="container">


### PR DESCRIPTION
- Make the install more prominent
- Point downloads to both the Engine and the Assets (separate buttons)
Here's a couple screen shots for the differences:
Before
![vs-gh-io_before](https://user-images.githubusercontent.com/1074110/149806730-41fc587f-25d0-4c01-a5a7-9f7041fc0242.png)
After
![vs-gh-io_after](https://user-images.githubusercontent.com/1074110/149806726-f88cf916-30a4-4b12-973c-bb4b275162ba.png)
